### PR TITLE
✏️ Fix typos in `tutorial.ipynb`

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -21,7 +21,7 @@
    "id": "b4e3ee38-20bb-4db9-9941-1b9f74f63af7",
    "metadata": {},
    "source": [
-    "This notebook will walk you through the process of solving an ordinary differential equation (ODE) using the `nnde` python package. The purpose of this notebook is to illustrate the use of the `nnde` package for solving a specific problem by identifying and performing each of the steps required to solve the problem."
+    "This notebook will walk you through the process of solving an ordinary differential equation (ODE) using the `nnde` Python package. The purpose of this notebook is to illustrate the use of the `nnde` package for solving a specific problem by identifying and performing each of the steps required to solve the problem."
    ]
   },
   {
@@ -29,7 +29,7 @@
    "id": "6354403b-8b63-4a06-b54a-5ef700d15b3b",
    "metadata": {},
    "source": [
-    "This tutorial shows how to solve an ODE interactively using a Jupyter notebook. For more complicated equations, we suggest placing the various required Python functions in an equation definition file. This file can then be passed to `nnde` to define the equation to solve. To see an example of this method, examine the example script `simple_01_nnde.py`."
+    "This tutorial shows how to solve an ODE interactively using a Jupyter notebook. For more complicated equations, we suggest placing the various required Python functions in an equation definition file. This file can then be passed to `nnde` to define the equation to solve. To see an example of this method, examine the example script [`simple_01_nnde.py`](https://github.com/elwinter/nnde_demos/blob/main/simple_01_nnde.py)."
    ]
   },
   {
@@ -59,7 +59,7 @@
    "source": [
     "The internal structure of the `nnde` package requires that certain naming conventions are followed by the user when defining code to be used by the `nnde` package.\n",
     "\n",
-    "The symbol $G$ is used to representhe the differential equation itself, written in the standard form:"
+    "The symbol $G$ is used to represent the differential equation itself, written in the standard form:"
    ]
   },
   {
@@ -355,7 +355,7 @@
     "    return x + (1 + 3*x**2)/(1 + x + x**3)\n",
     "\n",
     "\n",
-    "def dG_ddYdx(x, y, dY_dx):\n",
+    "def dG_ddYdx(x, Y, dY_dx):\n",
     "    return 1\n",
     "\n",
     "ic = 1"


### PR DESCRIPTION
- Fix `python` -> `Python`
- Add hyperlink to `simple_01_nnde.py`
- Fix `representhe` -> `represent`
- Fix function signature in definition of `dG_ddYdx`: renaming input variable `y` -> `Y`. Most of the previous sections in the narration preferred using `Y` instead of `y`.